### PR TITLE
Add max retries for downloader

### DIFF
--- a/streetview/download.py
+++ b/streetview/download.py
@@ -48,7 +48,9 @@ def make_download_url(pano_id: str, zoom: int, x: int, y: int) -> str:
     )
 
 
-def fetch_panorama_tile(tile_info: TileInfo, max_retries: int) -> Image.Image:
+def fetch_panorama_tile(
+    tile_info: TileInfo, max_retries: int = DEFAULT_MAX_RETRIES
+) -> Image.Image:
     """
     Tries to download a tile, returns a PIL Image.
     """
@@ -63,7 +65,7 @@ def fetch_panorama_tile(tile_info: TileInfo, max_retries: int) -> Image.Image:
 
 
 async def fetch_panorama_tile_async(
-    tile_info: TileInfo, max_retries: int
+    tile_info: TileInfo, max_retries: int = DEFAULT_MAX_RETRIES
 ) -> Image.Image:
     """
     Asynchronously tries to download a tile, returns a PIL Image.
@@ -96,7 +98,7 @@ def iter_tile_info(pano_id: str, zoom: int) -> Generator[TileInfo, None, None]:
 def iter_tiles(
     pano_id: str,
     zoom: int,
-    max_retries: int,
+    max_retries: int = DEFAULT_MAX_RETRIES,
     multi_threaded: bool = False,
 ) -> Generator[Tile, None, None]:
     if not multi_threaded:
@@ -123,7 +125,7 @@ def iter_tiles(
 
 
 async def iter_tiles_async(
-    pano_id: str, zoom: int, max_retries: int
+    pano_id: str, zoom: int, max_retries: int = DEFAULT_MAX_RETRIES
 ) -> AsyncGenerator[Tile, None]:
     for info in iter_tile_info(pano_id, zoom):
         image = await fetch_panorama_tile_async(info, max_retries)

--- a/streetview/download.py
+++ b/streetview/download.py
@@ -13,6 +13,9 @@ from PIL import Image
 async_client = httpx.AsyncClient()
 
 
+DEFAULT_MAX_RETRIES = 6
+
+
 @dataclass
 class TileInfo:
     x: int
@@ -45,34 +48,36 @@ def make_download_url(pano_id: str, zoom: int, x: int, y: int) -> str:
     )
 
 
-def fetch_panorama_tile(tile_info: TileInfo) -> Image.Image:
+def fetch_panorama_tile(tile_info: TileInfo, max_retries: int) -> Image.Image:
     """
     Tries to download a tile, returns a PIL Image.
     """
-    while True:
+    for _ in range(max_retries):
         try:
             response = requests.get(tile_info.fileurl, stream=True)
-            break
+            return Image.open(BytesIO(response.content))
         except requests.ConnectionError:
             print("Connection error. Trying again in 2 seconds.")
             time.sleep(2)
+    raise requests.ConnectionError("Max retries exceeded.")
 
-    return Image.open(BytesIO(response.content))
 
-
-async def fetch_panorama_tile_async(tile_info: TileInfo) -> Image.Image:
+async def fetch_panorama_tile_async(
+    tile_info: TileInfo, max_retries: int
+) -> Image.Image:
     """
     Asynchronously tries to download a tile, returns a PIL Image.
     """
-    while True:
+    for _ in range(max_retries):
         try:
             response = await async_client.get(tile_info.fileurl)
-            break
+            return Image.open(BytesIO(response.content))
+
         except httpx.RequestError as e:
             print(f"Request error {e}. Trying again in 2 seconds.")
             await asyncio.sleep(2)
 
-    return Image.open(BytesIO(response.content))
+    raise httpx.RequestError("Max retries exceeded.")
 
 
 def iter_tile_info(pano_id: str, zoom: int) -> Generator[TileInfo, None, None]:
@@ -89,17 +94,20 @@ def iter_tile_info(pano_id: str, zoom: int) -> Generator[TileInfo, None, None]:
 
 
 def iter_tiles(
-    pano_id: str, zoom: int, multi_threaded: bool = False
+    pano_id: str,
+    zoom: int,
+    max_retries: int,
+    multi_threaded: bool = False,
 ) -> Generator[Tile, None, None]:
     if not multi_threaded:
         for info in iter_tile_info(pano_id, zoom):
-            image = fetch_panorama_tile(info)
+            image = fetch_panorama_tile(info, max_retries)
             yield Tile(x=info.x, y=info.y, image=image)
         return
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future_to_tile = {
-            executor.submit(fetch_panorama_tile, info): info
+            executor.submit(fetch_panorama_tile, info, max_retries): info
             for info in iter_tile_info(pano_id, zoom)
         }
         for future in concurrent.futures.as_completed(future_to_tile):
@@ -107,40 +115,53 @@ def iter_tiles(
             try:
                 image = future.result()
             except Exception as exc:
-                print(f"{info.fileurl} generated an exception: {exc}")
+                raise Exception(
+                    f"Failed to download tile {info.fileurl} due to Exception: {exc}"
+                )
             else:
                 yield Tile(x=info.x, y=info.y, image=image)
 
 
-async def iter_tiles_async(pano_id: str, zoom: int) -> AsyncGenerator[Tile, None]:
+async def iter_tiles_async(
+    pano_id: str, zoom: int, max_retries: int
+) -> AsyncGenerator[Tile, None]:
     for info in iter_tile_info(pano_id, zoom):
-        image = await fetch_panorama_tile_async(info)
+        image = await fetch_panorama_tile_async(info, max_retries)
         yield Tile(x=info.x, y=info.y, image=image)
     return
 
 
 def get_panorama(
-    pano_id: str, zoom: int = 5, multi_threaded: bool = False
+    pano_id: str,
+    zoom: int = 5,
+    multi_threaded: bool = False,
+    max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> Image.Image:
     """
     Downloads a streetview panorama.
     Multi-threaded is a lot faster, but it's also a lot more likely to get you banned.
     """
-
     tile_width = 512
     tile_height = 512
 
     total_width, total_height = get_width_and_height_from_zoom(zoom)
     panorama = Image.new("RGB", (total_width * tile_width, total_height * tile_height))
 
-    for tile in iter_tiles(pano_id=pano_id, zoom=zoom, multi_threaded=multi_threaded):
+    for tile in iter_tiles(
+        pano_id=pano_id,
+        zoom=zoom,
+        multi_threaded=multi_threaded,
+        max_retries=max_retries,
+    ):
         panorama.paste(im=tile.image, box=(tile.x * tile_width, tile.y * tile_height))
         del tile
 
     return panorama
 
 
-async def get_panorama_async(pano_id: str, zoom: int) -> Image.Image:
+async def get_panorama_async(
+    pano_id: str, zoom: int, max_retries: int = DEFAULT_MAX_RETRIES
+) -> Image.Image:
     """
     Downloads a streetview panorama by iterating through the tiles asynchronously.
     This runs in about the same speed as `get_panorama` with `multi_threaded=True`.
@@ -151,7 +172,9 @@ async def get_panorama_async(pano_id: str, zoom: int) -> Image.Image:
     total_width, total_height = get_width_and_height_from_zoom(zoom)
     panorama = Image.new("RGB", (total_width * tile_width, total_height * tile_height))
 
-    async for tile in iter_tiles_async(pano_id=pano_id, zoom=zoom):
+    async for tile in iter_tiles_async(
+        pano_id=pano_id, zoom=zoom, max_retries=max_retries
+    ):
         panorama.paste(im=tile.image, box=(tile.x * tile_width, tile.y * tile_height))
         del tile
 


### PR DESCRIPTION
Having a `while True` in the library is scary. I have had infinite loops when I have a special bad panorama ID. 

Normal non-existent ID points to an url that's requestable, but gives back bad data, which causes the program to error out on the image parsing exception. There are also a few special bad ID that straight cannot be requested, and the program will keep trying til the end of the world. I don't have example IDs in hand at the moment, but please trust me on this. My guess is that these ID exists but are unpublished by Google due to whatever reason.

I'm suggesting to enforce a default `max_retries` of 6 for the download functions, and also make it to be user configurable.