### PR TITLE
Add optional timeouts to api calls

### DIFF
--- a/streetview/api.py
+++ b/streetview/api.py
@@ -18,7 +18,7 @@ class MetaData(BaseModel):
     copyright: str
 
 
-def get_panorama_meta(pano_id: str, api_key: str) -> MetaData:
+def get_panorama_meta(pano_id: str, api_key: str, timeout: int | None = None) -> MetaData:
     """
     Returns a panorama's metadata.
 
@@ -31,7 +31,7 @@ def get_panorama_meta(pano_id: str, api_key: str) -> MetaData:
         "https://maps.googleapis.com/maps/api/streetview/metadata"
         f"?pano={pano_id}&key={api_key}"
     )
-    resp = requests.get(url)
+    resp = requests.get(url, timeout=timeout)
     return MetaData(**resp.json())
 
 
@@ -73,6 +73,6 @@ def get_streetview(
         "key": api_key,
     }
 
-    response = requests.get(url, params=params, stream=True)
+    response = requests.get(url, params=params, stream=True, timeout=timeout)
     img = Image.open(BytesIO(response.content))
     return img

--- a/streetview/search.py
+++ b/streetview/search.py
@@ -34,13 +34,13 @@ def make_search_url(lat: float, lon: float) -> str:
     return url.format(lat, lon)
 
 
-def search_request(lat: float, lon: float) -> Response:
+def search_request(lat: float, lon: float, timeout: int | None = None) -> Response:
     """
     Gets the response of the script on Google's servers that returns the
     closest panoramas (ids) to a give GPS coordinate.
     """
     url = make_search_url(lat, lon)
-    return requests.get(url)
+    return requests.get(url, timeout=timeout)
 
 
 def extract_panoramas(text: str) -> List[Panorama]:
@@ -89,12 +89,12 @@ def extract_panoramas(text: str) -> List[Panorama]:
     ]
 
 
-def search_panoramas(lat: float, lon: float) -> List[Panorama]:
+def search_panoramas(lat: float, lon: float, timeout: int | None = None) -> List[Panorama]:
     """
     Gets the closest panoramas (ids) to the GPS coordinates.
     """
 
-    resp = search_request(lat, lon)
+    resp = search_request(lat, lon, timeout)
     pans = extract_panoramas(resp.text)
     return pans
 
@@ -113,21 +113,21 @@ def parse_url(url: str) -> tuple[str, ...]:
     return ("", "", "")
 
 
-def search_panoramas_url(url: str) -> list[Panorama]:
+def search_panoramas_url(url: str, timeout: int | None = None) -> list[Panorama]:
     """
     Gets the closest panoramas (ids) to the GPS coordinates in the url.
     """
     lat, lon, _ = parse_url(url)
-    return search_panoramas(float(lat), float(lon))
+    return search_panoramas(float(lat), float(lon), timeout)
 
 
-def search_panoramas_url_exact(url: str) -> Panorama | None:
+def search_panoramas_url_exact(url: str, timeout: int | None = None) -> Panorama | None:
     """
     Searches for exact panorama in url
     """
     _, _, id = parse_url(url)
 
-    panos = search_panoramas_url(url)
+    panos = search_panoramas_url(url, timeout)
     panos = [pano for pano in panos if pano.pano_id == id]
 
     return panos[0] if len(panos) > 0 else None


### PR DESCRIPTION
When making many API calls with this library, the likelihood that an HTTP request hangs indefinitely converges to 100%. To allow users to prevent this behavior, I've added an optional `timeout: int | None = None` argument to every function which makes a web request in the library.

Please let me know if any further changes would be helpful to get this through, or feel free to discard entirely if you'd like. Thank you!