### PR TITLE
fix: update Street View tile API endpoint (cbk0 → streetviewpixels-pa)

### DIFF
--- a/src/streetview/download.py
+++ b/src/streetview/download.py
@@ -43,8 +43,10 @@ def make_download_url(pano_id: str, zoom: int, x: int, y: int) -> str:
     Returns the URL to download a tile.
     """
     return (
-        "https://cbk0.google.com/cbk"
-        f"?output=tile&panoid={pano_id}&zoom={zoom}&x={x}&y={y}"
+        # "https://cbk0.google.com/cbk"
+        # f"?output=tile&panoid={pano_id}&zoom={zoom}&x={x}&y={y}"
+        "https://streetviewpixels-pa.googleapis.com/v1/tile"
+        f"?cb_client=maps_sv.tactile&panoid={pano_id}&x={x}&y={y}&zoom={zoom}"
     )
 
 


### PR DESCRIPTION
## Summary
Google deprecated the old Street View tile endpoint (`cbk0.google.com/cbk`) and replaced it with a new one. This PR updates the `make_download_url` function to use the new endpoint.

## Changes
- Replaced old tile URL: `https://cbk0.google.com/cbk?output=tile&panoid={pano_id}&zoom={zoom}&x={x}&y={y}`
- With new tile URL: `https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid={pano_id}&x={x}&y={y}&zoom={zoom}`
- Old URL is kept as a comment for reference

## Motivation
The previous endpoint stopped working after Google updated their Street View tile serving infrastructure, causing tile downloads to fail.